### PR TITLE
Fix `json:",omitempty"`

### DIFF
--- a/typescriptify/typescriptify.go
+++ b/typescriptify/typescriptify.go
@@ -523,6 +523,10 @@ func (t *TypeScriptify) getJSONFieldName(field reflect.StructField, isPtr bool) 
 		jsonTagParts := strings.Split(jsonTag, ",")
 		if len(jsonTagParts) > 0 {
 			jsonFieldName = strings.Trim(jsonTagParts[0], t.Indent)
+			//`json:",omitempty"` is valid
+			if jsonFieldName == "" {
+				jsonFieldName = field.Name
+			}
 		}
 		hasOmitEmpty := false
 		ignored := false


### PR DESCRIPTION
The json struct tag can be used without a first argument. In this case, the field name must be used.
See https://pkg.go.dev/encoding/json

Example code:

type Person struct {
	Phone        string       `json:",omitempty"`
}